### PR TITLE
Use AbstractExtension class instead of Twig_Extension

### DIFF
--- a/src/Twig/OcticonTwigExtension.php
+++ b/src/Twig/OcticonTwigExtension.php
@@ -4,8 +4,9 @@ namespace Octicons\Twig;
 
 use Octicons\Octicon;
 use Octicons\Options;
+use Twig\Extension\AbstractExtension;
 
-class OcticonTwigExtension extends \Twig_Extension
+class OcticonTwigExtension extends AbstractExtension
 {
     public function getFunctions(): array
     {


### PR DESCRIPTION
Hey Edwin. I've made the necessary change to the `OcticonTwigExtension` class. I ran your tests (all OK) and didn't conduct in-depth testing of my own because looking at the source for the new `AbstractExtension` class, it seems to be a clone of the `Twig_Extension` class. I'm happy to look into it further if you deem that necessary. 

Thanks,
Vidur