### PR TITLE
Properly document options for twig function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ A simple twig function is available for those who are using the [Twig templating
 ```
 Display an icon: {{ octicon("gear") }}
 
-Display an icon with extra css classes: {{ octicon("gear", ['classes' => ['background-red']]) }}
+Display an icon with extra css classes: {{ octicon("gear", 'background-red') }}
 
-Display an extra large icon: {{ octicon("gear", ['ratio' => 2]) }}
+Display an extra large icon: {{ octicon("gear", '', 2) }}
 ```
 
 ## Tests

--- a/src/Twig/OcticonTwigExtension.php
+++ b/src/Twig/OcticonTwigExtension.php
@@ -5,13 +5,16 @@ namespace Octicons\Twig;
 use Octicons\Octicon;
 use Octicons\Options;
 use Twig\Extension\AbstractExtension;
+use Twig\Markup;
+use Twig\TwigFunction;
+
 
 class OcticonTwigExtension extends AbstractExtension
 {
     public function getFunctions(): array
     {
         return [
-            new \Twig_Function('octicon', function (string $name, $classes = '', int $ratio = 1) {
+            new TwigFunction('octicon', function (string $name, $classes = '', int $ratio = 1) {
                 $octicon = new Octicon();
                 $options = new Options();
 
@@ -21,7 +24,7 @@ class OcticonTwigExtension extends AbstractExtension
 
                 $options->setRatio($ratio);
 
-                return new \Twig_Markup($octicon->icon($name, $options)->toSvg(), 'UTF-8');
+                return new Markup($octicon->icon($name, $options)->toSvg(), 'UTF-8');
             }),
         ];
     }


### PR DESCRIPTION
$classes and $ratio are optional parameters to the twig function