### PR TITLE
Upgrading Twig to ^3.0, and PHP to 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "^6.5",
         "mockery/mockery": "^1.0",
-        "twig/twig": "^3.0",
+        "twig/twig": "^2.10|^3.0",
         "php-coveralls/php-coveralls": "^2.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     },
     "require": {
-        "php": ">= 7.0"
+        "php": ">= 7.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",
         "mockery/mockery": "^1.0",
-        "twig/twig": "^2.4",
+        "twig/twig": "^3.0",
         "php-coveralls/php-coveralls": "^2.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "php": ">= 7.2"
+        "php": ">= 7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",

--- a/src/Twig/OcticonTwigExtension.php
+++ b/src/Twig/OcticonTwigExtension.php
@@ -2,16 +2,16 @@
 
 namespace Octicons\Twig;
 
-use Octicons\Octicon;
-use Octicons\Options;
+use Octicons\{Octicon, Options};
 use Twig\Extension\AbstractExtension;
+use Twig\{TwigFunction, Markup};
 
 class OcticonTwigExtension extends AbstractExtension
 {
     public function getFunctions(): array
     {
         return [
-            new \Twig_Function('octicon', function (string $name, $classes = '', int $ratio = 1) {
+            new TwigFunction('octicon', function (string $name, $classes = '', int $ratio = 1) {
                 $octicon = new Octicon();
                 $options = new Options();
 
@@ -21,7 +21,7 @@ class OcticonTwigExtension extends AbstractExtension
 
                 $options->setRatio($ratio);
 
-                return new \Twig_Markup($octicon->icon($name, $options)->toSvg(), 'UTF-8');
+                return new Markup($octicon->icon($name, $options)->toSvg(), 'UTF-8');
             }),
         ];
     }


### PR DESCRIPTION
Twig 3.0 has been available for a few months now, and the older `\Twig_Function` is no-longer existent.  In order for the extension to work, it needs to use `\Twig\TwigFunction` instead.